### PR TITLE
Add a way to get RTSP status

### DIFF
--- a/src/SharpRTSPClient/RTSPClient.cs
+++ b/src/SharpRTSPClient/RTSPClient.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Rtsp;
 using Rtsp.Messages;
 using Rtsp.Onvif;
@@ -57,7 +57,7 @@ namespace SharpRTSPClient
 
         public bool AutoPlay { get; set; } = true;
 
-        private enum RtspStatus { WaitingToConnect, Connecting, ConnectFailed, Connected };
+        public enum RtspStatus { WaitingToConnect, Connecting, ConnectFailed, Connected };
 
         private IRtspTransport _rtspSocket; // RTSP connection
         private RtspStatus _rtspSocketStatus = RtspStatus.WaitingToConnect;
@@ -354,6 +354,14 @@ namespace SharpRTSPClient
         }
 
         /// <summary>
+        /// Returns the current RTSP status.
+        /// </summary>
+        /// <returns>The current RTSP status.</returns>
+        public RtspStatus GetRtspStatus()
+        {
+            return _rtspSocketStatus;
+        }
+        /// <summary>
         /// Pause.
         /// </summary>
         /// <exception cref="InvalidOperationException"></exception>
@@ -451,6 +459,7 @@ namespace SharpRTSPClient
         public void Stop()
         {
             StopClient();
+            _rtspSocketStatus = RtspStatus.WaitingToConnect;
         }
 
         private void StopClient()


### PR DESCRIPTION
1.Add a way to get RTSP status
2.Reset the state when you actively call Stop()

Reason for change：
When doing real-time preview and switching of multiple streams, you can create and reuse RTSPClient instances in advance. Call connect when you need to play, and call stop when you don't. Before calling, you can use rtspstatus to check the status of the current instance to avoid repeated calls and some errors.